### PR TITLE
Change artifactType compare to lowercase compare

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -297,7 +297,7 @@ export class TfsRestService implements ITfsRestService {
         console.log(`Found ${result.length} artifact(s)`);
 
         for (let artifact of result) {
-            if (artifact.resource.type !== "Container") {
+            if (artifact.resource.type.toLowerCase() !== "container") {
                 console.log(`Cannot download artifact ${artifact.name}. Only Containers are supported (type is \"${artifact.resource.type}\)"`);
                 continue;
             }

--- a/index.ts
+++ b/index.ts
@@ -298,7 +298,7 @@ export class TfsRestService implements ITfsRestService {
 
         for (let artifact of result) {
             if (artifact.resource.type.toLowerCase() !== "container") {
-                console.log(`Cannot download artifact ${artifact.name}. Only Containers are supported (type is \"${artifact.resource.type}\)"`);
+                console.log(`Cannot download artifact ${artifact.name}. Only Containers are supported (type is \"${artifact.resource.type}"\)`);
                 continue;
             }
 


### PR DESCRIPTION
It appears that Azure Devops can store artifacts with types in differing cases. On Azure Devops Server 2019, the Publish Build artifact built-in task ends up publishing with artifact type "`container`" which then cannot be downloaded my TfsRestService due to the casing not being "`Container`".

Other tasks appear to use a `toLowerCase()` before comparing artifactTypes, this change is to do the same here.
(ie. https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/PublishBuildArtifactsV1/publishbuildartifacts.ts#L63)

